### PR TITLE
cache editorial content on fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# cortex-editorial-view
+
+### 2.0.0
+
+* fetch and cache feed image assets when feed is fetched.  this makes the `get`
+  method incompatible with earlier versions which returned a deferred.  now just
+  returns a local path

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -1,5 +1,6 @@
 (function() {
-  var $, CortexNet, EditorialFeed, promise, ref;
+  var $, CortexNet, EditorialFeed, promise, ref,
+    bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
   promise = require('promise');
 
@@ -9,8 +10,8 @@
 
   EditorialFeed = (function() {
     function EditorialFeed(feedXml, opts) {
-      var fetch;
       this.feedXml = feedXml;
+      this.fetch = bind(this.fetch, this);
       if (opts == null) {
         opts = {};
       }
@@ -27,30 +28,14 @@
         this.feedCachePeriod = opts.feedCachePeriod;
       }
       this.imageIndex = 0;
-      this.cacheIndex = 1;
       this.images = [];
-      fetch = (function(_this) {
-        return function() {
-          return _this.fetch();
-        };
-      })(this);
-      setInterval(fetch, this.feedCachePeriod);
+      setInterval(this.fetch, this.feedCachePeriod);
       this.fetch();
     }
 
     EditorialFeed.prototype.get = function() {
-      console.log("EditorialFeed will return on of the " + this.images.length + " images in " + this.feedXml);
-      return new promise((function(_this) {
-        return function(resolve, reject) {
-          var image;
-          image = _this._selectImage();
-          if (image != null) {
-            return _this._cache(image).then(resolve)["catch"](reject);
-          } else {
-            return reject(new Error("No editorial content is available."));
-          }
-        };
-      })(this));
+      console.log("EditorialFeed will return one of the " + this.images.length + " images in " + this.feedXml);
+      return this._selectImage();
     };
 
     EditorialFeed.prototype.fetch = function() {
@@ -69,18 +54,31 @@
           if (CortexNet != null) {
             return CortexNet.download(_this.feedXml, opts, (function(file) {
               return $.get(file, (function(data) {
-                var images;
-                images = _this._parse(data);
-                if ((images != null) && images.length > 0) {
-                  console.log("Replacing images " + _this.images.length + " -> " + images.length);
-                  _this.images = images;
+                var imageUrls, promises, url;
+                imageUrls = _this._parse(data);
+                if ((imageUrls != null) && imageUrls.length > 0) {
+                  console.log("Replacing images " + _this.images.length + " -> " + imageUrls.length);
+                  promises = (function() {
+                    var i, len, results;
+                    results = [];
+                    for (i = 0, len = imageUrls.length; i < len; i++) {
+                      url = imageUrls[i];
+                      results.push(this._cache(url));
+                    }
+                    return results;
+                  }).call(_this);
+                  promise.all(promises).then(function(res) {
+                    return _this.images = res;
+                  }).done();
                 }
                 return resolve();
               })).fail(function(e) {
+                _this.images = [];
                 console.log("Failed to fetch local editorial feed. e=", e);
                 return reject(e);
               });
             }), (function(e) {
+              _this.images = [];
               console.log("Failed to fetch remote editorial feed. e=", e);
               return reject(e);
             }));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-editorial-view",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Editorial content view for Cortex applications",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
ran into an issue where even though it was caching the feed, if the
network went down before each image was displayed it would fail
- change `get` method to return a local path
- @images list to contain cached image paths
- empty @images list on error
