### PR TITLE
cache editorial content on fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# cortex-editorial-view
+
+### 2.0.0
+
+* fetch and cache feed image assets when feed is fetched.  this makes the `get`
+  method incompatible with earlier versions which returned a deferred.  now just
+  returns a local path

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -1,5 +1,6 @@
 (function() {
-  var $, CortexNet, EditorialFeed, promise, ref;
+  var $, CortexNet, EditorialFeed, promise, ref,
+    bind = function(fn, me){ return function(){ return fn.apply(me, arguments); }; };
 
   promise = require('promise');
 
@@ -9,11 +10,13 @@
 
   EditorialFeed = (function() {
     function EditorialFeed(feedXml, opts) {
-      var fetch;
       this.feedXml = feedXml;
+      this._cache = bind(this._cache, this);
+      this.fetch = bind(this.fetch, this);
       if (opts == null) {
         opts = {};
       }
+      this._requestThrottleMs = 1000;
       this.assetCacheTTL = 7 * 24 * 60 * 60 * 1000;
       if (opts.assetCacheTTL != null) {
         this.assetCacheTTL = opts.assetCacheTTL;
@@ -27,30 +30,14 @@
         this.feedCachePeriod = opts.feedCachePeriod;
       }
       this.imageIndex = 0;
-      this.cacheIndex = 1;
       this.images = [];
-      fetch = (function(_this) {
-        return function() {
-          return _this.fetch();
-        };
-      })(this);
-      setInterval(fetch, this.feedCachePeriod);
+      setInterval(this.fetch, this.feedCachePeriod);
       this.fetch();
     }
 
     EditorialFeed.prototype.get = function() {
-      console.log("EditorialFeed will return on of the " + this.images.length + " images in " + this.feedXml);
-      return new promise((function(_this) {
-        return function(resolve, reject) {
-          var image;
-          image = _this._selectImage();
-          if (image != null) {
-            return _this._cache(image).then(resolve)["catch"](reject);
-          } else {
-            return reject(new Error("No editorial content is available."));
-          }
-        };
-      })(this));
+      console.log("EditorialFeed will return one of the " + this.images.length + " images in " + this.feedXml);
+      return this._selectImage();
     };
 
     EditorialFeed.prototype.fetch = function() {
@@ -69,18 +56,33 @@
           if (CortexNet != null) {
             return CortexNet.download(_this.feedXml, opts, (function(file) {
               return $.get(file, (function(data) {
-                var images;
-                images = _this._parse(data);
-                if ((images != null) && images.length > 0) {
-                  console.log("Replacing images " + _this.images.length + " -> " + images.length);
-                  _this.images = images;
+                var i, imageUrls, promises, url;
+                imageUrls = _this._parse(data);
+                if ((imageUrls != null) && imageUrls.length > 0) {
+                  console.log("Replacing images " + _this.images.length + " -> " + imageUrls.length);
+                  promises = (function() {
+                    var j, len, results;
+                    results = [];
+                    for (i = j = 0, len = imageUrls.length; j < len; i = ++j) {
+                      url = imageUrls[i];
+                      results.push(this._cache(url, i * this._requestThrottleMs));
+                    }
+                    return results;
+                  }).call(_this);
+                  promise.all(promises).then(function(res) {
+                    return _this.images = res;
+                  })["catch"](function(e) {
+                    return console.error(e);
+                  }).done();
                 }
                 return resolve();
               })).fail(function(e) {
+                _this.images = [];
                 console.log("Failed to fetch local editorial feed. e=", e);
                 return reject(e);
               });
             }), (function(e) {
+              _this.images = [];
               console.log("Failed to fetch remote editorial feed. e=", e);
               return reject(e);
             }));
@@ -92,13 +94,13 @@
     };
 
     EditorialFeed.prototype._parse = function(data) {
-      var i, images, img, item, items, len, url, xml, xmlDoc;
+      var images, img, item, items, j, len, url, xml, xmlDoc;
       xmlDoc = $.parseXML(data);
       xml = $(xmlDoc);
       items = xml.find('item');
       images = [];
-      for (i = 0, len = items.length; i < len; i++) {
-        item = items[i];
+      for (j = 0, len = items.length; j < len; j++) {
+        item = items[j];
         item = $(item);
         img = item.find('media\\:content, content');
         url = img.attr('url');
@@ -121,10 +123,13 @@
       return image;
     };
 
-    EditorialFeed.prototype._cache = function(image) {
+    EditorialFeed.prototype._cache = function(image, wait) {
+      if (wait == null) {
+        wait = 0;
+      }
       return new promise((function(_this) {
         return function(resolve, reject) {
-          var opts;
+          var error, fetch, opts, success;
           if (CortexNet != null) {
             opts = {
               cache: {
@@ -134,13 +139,18 @@
               stripBom: false,
               retry: 3
             };
-            return CortexNet.download(image, opts, (function(path) {
-              console.log("Cached image " + image + " => " + path);
-              return resolve(path);
-            }), (function(err) {
+            error = function(e) {
               console.log("Failed to cache image " + image + ", err=", err);
               return reject(err);
-            }));
+            };
+            success = function(path) {
+              console.log("Cached image " + image + " => " + path);
+              return resolve(path);
+            };
+            fetch = function() {
+              return CortexNet.download(image, opts, success, error);
+            };
+            return setTimeout(fetch, wait);
           } else {
             console.log("Cortex network is not available. ");
             return resolve(image);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cortex-editorial-view",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Editorial content view for Cortex applications",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
ran into an issue where even though it was caching the feed, if the
network went down before each image was displayed it would fail
- change `get` method to return a local path
- @images list to contain cached image paths
- empty @images list on error
- throttle requests for editorial images
